### PR TITLE
Extract useInactivityPoller hook

### DIFF
--- a/src/hooks/useInactivityPoller.ts
+++ b/src/hooks/useInactivityPoller.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface UseInactivityPollerOptions {
+    intervalMs: number;
+    maxTicks: number;
+}
+
+/** Wrap fetchFn in useCallback to keep the interval stable across renders. */
+export function useInactivityPoller(
+    fetchFn: () => Promise<void>,
+    { intervalMs, maxTicks }: UseInactivityPollerOptions,
+) {
+    const [initialLoading, setInitialLoading] = useState(true);
+    const [showInactivityModal, setShowInactivityModal] = useState(false);
+    const tickCountRef = useRef(0);
+
+    const poll = useCallback(async () => {
+        if (tickCountRef.current >= maxTicks) {
+            setShowInactivityModal(true);
+            return;
+        }
+        await fetchFn();
+        tickCountRef.current += 1;
+    }, [fetchFn, maxTicks]);
+
+    useEffect(() => {
+        poll().then(() => setInitialLoading(false));
+        const timer = window.setInterval(poll, intervalMs);
+        return () => window.clearInterval(timer);
+    }, [poll, intervalMs]);
+
+    const resetActivity = useCallback(() => {
+        tickCountRef.current = 0;
+    }, []);
+
+    const onInactivityContinue = useCallback(async () => {
+        resetActivity();
+        setShowInactivityModal(false);
+        await poll();
+    }, [poll, resetActivity]);
+
+    const toggleInactivityModal = useCallback(() => {
+        setShowInactivityModal(v => !v);
+    }, []);
+
+    return {
+        initialLoading,
+        showInactivityModal,
+        toggleInactivityModal,
+        onInactivityContinue,
+        resetActivity,
+    };
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,133 +1,84 @@
-﻿import React from "react";
+import React, { useCallback, useState } from "react";
 import './Home.css'
 import PlayersService from "../players/players-service";
-import {Player} from "../players/player";
+import { Player } from "../players/player";
 import PlayerTableRecord from "../../table/PlayerTableRecord";
 import CharityService from "../Charities/charity-service";
 import Charity from "../Charities/charity";
 import LoadingSpinner from "../../loader/LoadingSpinner";
 import InactivityModal from "../../modals/InactivityModal";
+import { useInactivityPoller } from "../../hooks/useInactivityPoller";
 
-class Home extends React.Component<{}, {players: Player[], charities: Charity[], loading: boolean, showInactivityModal: boolean, requestSent: number}> {
+const playerService = new PlayersService();
+const charityService = new CharityService();
 
-    playerService = new PlayersService();
-    charityService = new CharityService();
+function Home() {
+    const [players, setPlayers] = useState<Player[]>([]);
+    const [charities, setCharities] = useState<Charity[]>([]);
 
-    timer: number = 0;
-    //5 minutes
-    rateLimit: number = 30;
-
-    constructor(props: {}) {
-        super(props);
-        this.state = {
-            charities: [],
-            players: [],
-            loading: false,
-            showInactivityModal: false,
-            requestSent: 0
-        }
-    }
-
-    async componentDidMount() {
-        await this.setState({
-            loading: true,
-        });
-        await this.getTableData();
-        await this.setState({
-            loading: false,
-        });
-        this.timer = window.setInterval(() => this.getTableData(), 10000);
-    }
-
-    componentWillUnmount() {
-        window.clearInterval(this.timer);
-    }
-
-    async getTableData() {
-        if (this.state?.requestSent >= this.rateLimit) {
-            this.setState({
-                showInactivityModal: true,
-                loading: false,
-            })
-            return;
-        }
-        const players = await this.playerService.getPlayers();
-        const charities: Charity[] = await this.charityService.getCharityIds();
-        for (let i = 0; i < charities.length; i++) {
-            const charity = charities[i];
+    const fetchTableData = useCallback(async () => {
+        const nextPlayers = await playerService.getPlayers();
+        const nextCharities: Charity[] = await charityService.getCharityIds();
+        for (const charity of nextCharities) {
             try {
-                charity.justGivingCharity = await this.charityService.getCharityDetails(charity.id);
+                charity.justGivingCharity = await charityService.getCharityDetails(charity.id);
             } catch (e) {
                 //Some charities can not be found
                 console.log(e);
             }
         }
-        await this.setState({
-            players: players,
-            charities: charities,
-            requestSent: this.state?.requestSent + 1
-        });
-    }
+        setPlayers(nextPlayers);
+        setCharities(nextCharities);
+    }, []);
 
-    toggleInactivityModal = () => {
-        this.setState({
-            showInactivityModal: !this.state.showInactivityModal
-        })
-    }
-    
-    onInactivityModalContinuePressed = async () => {
-        await this.setState({
-            requestSent : 0,
-            showInactivityModal: false
-        })
-        this.getTableData();
-    }
+    const {
+        initialLoading,
+        showInactivityModal,
+        toggleInactivityModal,
+        onInactivityContinue,
+    } = useInactivityPoller(fetchTableData, { intervalMs: 10000, maxTicks: 30 });
 
-    render() {
-        if (this.state?.loading) {
-            return <LoadingSpinner/>
-        } else {
-            return (
-                <div>
-                    <InactivityModal show={this.state?.showInactivityModal} toggle={this.toggleInactivityModal} continueButtonOnClick={this.onInactivityModalContinuePressed}/>
-                    <h1 className="title">DonateCraft</h1>
-                    <div className="leaderboards">
-                        <div className="death-leaderboard-container">
-                            <p className="most-deaths">Most deaths</p>
-                            <table
-                                className="death-leaderboard-table table-striped table table-hover table-responsive table-bordered">
-                                <tbody>
-                                {
-                                    this.state?.players?.map((player) => (
-                                        <PlayerTableRecord player={player}/>
-                                    ))
-                                }
-                                </tbody>
-                            </table>
-                        </div>
-                        <div className="top-charity-leaderboard-container">
-                            <p className="most-deaths">Charity donation count</p>
-                            <table
-                                className="charity-leaderboard-table table-striped table table-hover table-responsive table-bordered">
-                                <tbody>
-                                {
-                                    this.state?.charities?.map((charity) => (
-                                        <tr key={charity.id}>
-                                            <td className="charity-table-data">
-                                                <span>{charity.justGivingCharity.name}</span></td>
-                                            <td className="charity-table-data charity-table-data-donations">{charity.donationCount}</td>
-                                        </tr>
-                                    ))
-                                }
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+    if (initialLoading) {
+        return <LoadingSpinner/>;
+    }
+    return (
+        <div>
+            <InactivityModal show={showInactivityModal} toggle={toggleInactivityModal} continueButtonOnClick={onInactivityContinue}/>
+            <h1 className="title">DonateCraft</h1>
+            <div className="leaderboards">
+                <div className="death-leaderboard-container">
+                    <p className="most-deaths">Most deaths</p>
+                    <table
+                        className="death-leaderboard-table table-striped table table-hover table-responsive table-bordered">
+                        <tbody>
+                        {
+                            players.map((player) => (
+                                <PlayerTableRecord player={player}/>
+                            ))
+                        }
+                        </tbody>
+                    </table>
                 </div>
-
-            )
-        }
-    }
+                <div className="top-charity-leaderboard-container">
+                    <p className="most-deaths">Charity donation count</p>
+                    <table
+                        className="charity-leaderboard-table table-striped table table-hover table-responsive table-bordered">
+                        <tbody>
+                        {
+                            charities.map((charity) => (
+                                <tr key={charity.id}>
+                                    <td className="charity-table-data">
+                                        <span>{charity.justGivingCharity.name}</span></td>
+                                    <td className="charity-table-data charity-table-data-donations">{charity.donationCount}</td>
+                                </tr>
+                            ))
+                        }
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    );
 }
 
 export default Home;

--- a/src/pages/players/Players.tsx
+++ b/src/pages/players/Players.tsx
@@ -1,161 +1,107 @@
-﻿import React from "react";
+import React, { useCallback, useState } from "react";
 import PlayersService from "./players-service";
-import {Player} from "./player";
-import {Donation} from "./donation";
+import { Player } from "./player";
+import { Donation } from "./donation";
 import './Player.css';
 import LoadingSpinner from "../../loader/LoadingSpinner";
 import PlayerSelector from "../../modals/PlayerSelector";
 import InactivityModal from "../../modals/InactivityModal";
+import { useInactivityPoller } from "../../hooks/useInactivityPoller";
 
+const playerService = new PlayersService();
 
-export default class Players extends React.Component<{}, { players: Player[], loading: boolean, showPlayerSelector: boolean, showInactivityModal: boolean, currentRateLimit: number, currentPlayer: Player | null }> {
+function getDonationTotal(donations: Donation[]): string {
+    let total = 0;
+    for (const donation of donations) {
+        total += donation.amount;
+    }
+    return total.toFixed(2);
+}
 
-    playerService = new PlayersService();
-    timer : number = 0;
-    //5 minutes
-    rateLimit: number = 30;
-    
-    constructor(props: any) {
-        super(props);
-        this.state = {
-            players: [],
-            loading: false,
-            showPlayerSelector: false,
-            showInactivityModal: false,
-            currentRateLimit: 0,
-            currentPlayer: null
-        }        
-    }
-    
-    async componentDidMount() {
-        this.setState({
-            loading: true,
-        });
-        await this.getPlayers();
-        this.setState({
-            loading: false,
-        });
-        this.timer = window.setInterval(()=> this.getPlayers(), 10000);
-    }
-    
-    componentWillUnmount() {
-        window.clearInterval(this.timer);
-    }
+export default function Players() {
+    const [players, setPlayers] = useState<Player[]>([]);
+    const [showPlayerSelector, setShowPlayerSelector] = useState(false);
+    const [currentPlayer, setCurrentPlayer] = useState<Player | null>(null);
 
-    async getPlayers() {
-        if (this.state.currentRateLimit >= this.rateLimit) {
-            this.setState({
-                showInactivityModal: true,
-                showPlayerSelector: false,
-                loading: false,
-            })
-            return;
-        }
-        const playerList: Player[] = await this.playerService.getPlayers();
-        this.setState({
-            players : playerList,
-            currentRateLimit : this.state.currentRateLimit + 1
-        });
-    }
+    const fetchPlayers = useCallback(async () => {
+        const playerList = await playerService.getPlayers();
+        setPlayers(playerList);
+    }, []);
 
-    getDonationTotal(donations : Donation[]) : string {
-        let total = 0;
-        for (const donation of donations){
-            total += donation.amount;
-        }
-        return total.toFixed(2);
-    }
-    
-    onPlayerDonateClicked(currentPlayer: Player) {
-        this.setState({
-            showPlayerSelector: true,
-            //Player is clearly active on page
-            currentRateLimit : 0,
-            currentPlayer: currentPlayer
-        })
-    }
-    
-    onModalPlayerSelected = (player: Player, donor: Player) => {
-        this.setState({
-            showPlayerSelector: false
-        })
+    const {
+        initialLoading,
+        showInactivityModal,
+        toggleInactivityModal,
+        onInactivityContinue,
+        resetActivity,
+    } = useInactivityPoller(fetchPlayers, { intervalMs: 10000, maxTicks: 30 });
+
+    const onPlayerDonateClicked = (player: Player) => {
+        setShowPlayerSelector(true);
+        setCurrentPlayer(player);
+        resetActivity();
+    };
+
+    const onModalPlayerSelected = (player: Player, donor: Player) => {
+        setShowPlayerSelector(false);
         let url = `/charities?playerId=${player.id}`;
         if (player.id !== donor.id) {
             url += `&donorId=${donor.id}`;
         }
         window.location.replace(url);
+    };
+
+    const toggleModal = () => setShowPlayerSelector(prev => !prev);
+
+    if (players.length === 0 && !initialLoading) {
+        return <div className="no-players-text"><span data-testid="noPlayers">No players ☹</span></div>;
     }
-    
-    toggleModal = () => {
-        this.setState({
-            showPlayerSelector: !this.state.showPlayerSelector
-        })
+    if (initialLoading) {
+        return <LoadingSpinner/>;
     }
-    toggleInactivityModal = () => {
-        this.setState({
-            showInactivityModal: !this.state.showInactivityModal
-        })
-    }
-    
-    onInactivityModalContinuePressed = async () => {
-        await this.setState({
-            currentRateLimit : 0,
-            showInactivityModal: false
-        })
-        this.getPlayers();
-    }
-    
-    render(){
-        if (this.state && this.state.players && this.state.players.length == 0 && !this.state.loading) {
-            return <div className="no-players-text"><span data-testid="noPlayers">No players ☹</span></div>
-        } else if (this.state.loading) {
-            return <LoadingSpinner/>
-        } else if (this.state && this.state.players && this.state.players.length !== 0){
-            return (
-                <div>
-                    <InactivityModal show={this.state.showInactivityModal} toggle={this.toggleInactivityModal} continueButtonOnClick={this.onInactivityModalContinuePressed}/>
-                    <PlayerSelector players={this.state.players} currentPlayer={this.state.currentPlayer} show={this.state.showPlayerSelector} toggle={this.toggleModal} playerSelected={this.onModalPlayerSelected}/>
-                    <table className="players-table table-striped table table-hover table-responsive table-bordered" data-testid="playersTable">
-                        <thead className="table-light">
-                            <tr>
-                                <th>Player</th>
-                                <th>Last Death Reason</th>
-                                <th>Status</th>
-                                <th>Death Count</th>
-                                <th>Dontation Total</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {
-                            this.state.players.map((player) => (
-                                <tr className="players-row" key={player.id}>
-                                    <td className="players-table-data-image">
-                                        <div className="player-info-container">
-                                            <img className="players-image" data-testid="playerImage" src={`https://crafthead.net/avatar/${player.id}` } />
-                                            <span data-testid="playerName" className="player-name">{player.name}</span>
-                                        </div>
-                                    </td>
-                                    <td className="players-table-data death-reason" data-testid="playerDeathReason">{player.deaths.length > 0 ? player.deaths[player.deaths.length - 1].reason : "No deaths!"}</td>
-                                    <td className="players-table-data" data-testid="playerDeathStatus">
-                                        {
-                                            player.isDead ?
-                                            <div className="player-dead">
-                                                <span className="player-dead-text">Dead</span>
-                                                <button className="btn btn-success player-donate-button" data-testid="playerDeadButton" onClick={() => this.onPlayerDonateClicked(player)}>Donate</button>
-                                             </div> 
-                                            : 
-                                            <span className="player-alive-text">Alive</span>
-                                        }
-                                    </td>
-                                    <td className="players-table-data" data-testid="playerDeathCount">{player.deaths.length}</td>
-                                    <td className="players-table-data" data-testid="playerDonationSum">£{this.getDonationTotal(player.donations)}</td>
-                                </tr>
-                            ))
-                        }
-                        </tbody>
-                    </table>
-                </div>
-            )
-        }
-    }    
+    return (
+        <div>
+            <InactivityModal show={showInactivityModal} toggle={toggleInactivityModal} continueButtonOnClick={onInactivityContinue}/>
+            <PlayerSelector players={players} currentPlayer={currentPlayer} show={showPlayerSelector && !showInactivityModal} toggle={toggleModal} playerSelected={onModalPlayerSelected}/>
+            <table className="players-table table-striped table table-hover table-responsive table-bordered" data-testid="playersTable">
+                <thead className="table-light">
+                    <tr>
+                        <th>Player</th>
+                        <th>Last Death Reason</th>
+                        <th>Status</th>
+                        <th>Death Count</th>
+                        <th>Dontation Total</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {
+                    players.map((player) => (
+                        <tr className="players-row" key={player.id}>
+                            <td className="players-table-data-image">
+                                <div className="player-info-container">
+                                    <img className="players-image" data-testid="playerImage" src={`https://crafthead.net/avatar/${player.id}`} />
+                                    <span data-testid="playerName" className="player-name">{player.name}</span>
+                                </div>
+                            </td>
+                            <td className="players-table-data death-reason" data-testid="playerDeathReason">{player.deaths.length > 0 ? player.deaths[player.deaths.length - 1].reason : "No deaths!"}</td>
+                            <td className="players-table-data" data-testid="playerDeathStatus">
+                                {
+                                    player.isDead ?
+                                    <div className="player-dead">
+                                        <span className="player-dead-text">Dead</span>
+                                        <button className="btn btn-success player-donate-button" data-testid="playerDeadButton" onClick={() => onPlayerDonateClicked(player)}>Donate</button>
+                                     </div>
+                                    :
+                                    <span className="player-alive-text">Alive</span>
+                                }
+                            </td>
+                            <td className="players-table-data" data-testid="playerDeathCount">{player.deaths.length}</td>
+                            <td className="players-table-data" data-testid="playerDonationSum">£{getDonationTotal(player.donations)}</td>
+                        </tr>
+                    ))
+                }
+                </tbody>
+            </table>
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
- Extract the poll-with-inactivity pattern (interval timer + rate-limit counter + inactivity modal) into a reusable `useInactivityPoller` hook.
- Convert `Players` and `Home` from class components to function components using the hook. Each page drops ~25 lines of duplicated boilerplate.
- `Players` derives selector visibility from `showInactivityModal` (`show={showPlayerSelector && !showInactivityModal}`) instead of a custom callback, so the hook API stays minimal.

## Notes
- Hook contract: caller must wrap `fetchFn` in `useCallback` to keep the interval stable across renders.
- Same behavior as before: 30 polls at 10s intervals (~5min) before pausing. `resetActivity()` is called on donate-click to preserve the "user is clearly active" behavior.
- Revivals also uses this pattern but lives on the `feature/revivals` branch. It will be refactored to use the hook when that branch rebases.
- Heads up: two pre-existing tests fail on `main` due to a stale avatar URL (`crafatar.com` vs `crafthead.net`). Not touched here so the PR stays focused on the refactor.

## Test plan
- [x] `npm test` passes locally (except the two pre-existing broken tests noted above)
- [x] `npx tsc --noEmit` clean
- [ ] Manually verify inactivity modal appears after 30 polls on Home and Players
- [ ] Manually verify "Continue" resumes polling with fresh data
- [ ] Manually verify clicking "Donate" on Players resets the inactivity counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)