### PR TITLE
Add revival credits: Buy Revivals button and Credits column

### DIFF
--- a/src/pages/Charities/Charities.tsx
+++ b/src/pages/Charities/Charities.tsx
@@ -14,7 +14,8 @@ class Charities extends React.Component<{}, {charities: Charity[], players: Play
     playerService = new PlayersService();
     playerId = '';
     donorId = '';
-    
+    mode = '';
+
     constructor(props: any) {
         super(props);
         this.state = {
@@ -27,6 +28,16 @@ class Charities extends React.Component<{}, {charities: Charity[], players: Play
         const params = new URLSearchParams(window.location.search);
         this.playerId = params.get('playerId') ?? '';
         this.donorId = params.get('donorId') ?? '';
+        this.mode = params.get('mode') ?? '';
+    }
+
+    private buildDonationUrl(charityId: number, playerId: string, donorId?: string): string {
+        const prefix = this.mode === 'credits' ? 'credits~JUSTGIVING-DONATION-ID' : 'JUSTGIVING-DONATION-ID';
+        let url = `${process.env.REACT_APP_JG_DONATE_URL}${charityId}?exiturl=${process.env.REACT_APP_API_URL}v1/Callback?data=${prefix}~${playerId}`;
+        if (this.mode !== 'credits' && donorId && donorId !== '') {
+            url += `~${donorId}`;
+        }
+        return url;
     }
     
     async componentDidMount() {
@@ -52,7 +63,7 @@ class Charities extends React.Component<{}, {charities: Charity[], players: Play
     }
 
     async charityDonateButtonClicked(charity: Charity) {
-        
+
         if (!this.playerId) {
             await this.setState({
                 loading: true
@@ -66,19 +77,15 @@ class Charities extends React.Component<{}, {charities: Charity[], players: Play
             })
             return;
         }
-        
-        let url = `${process.env.REACT_APP_JG_DONATE_URL}${charity.id}?exiturl=${process.env.REACT_APP_API_URL}v1/Callback?data=JUSTGIVING-DONATION-ID~${this.playerId}`;
-        if (this.donorId && this.donorId !== '') {
-            url += `~${this.donorId}`;
-        }
-        window.location.replace(url);
+
+        window.location.replace(this.buildDonationUrl(charity.id, this.playerId, this.donorId));
     }
 
     onModalPlayerSelected = (currentPlayer: Player, selectedPlayer: Player) => {
         this.setState({
             showPlayerSelector: false
         })
-        if (!selectedPlayer.isDead) {
+        if (this.mode !== 'credits' && !selectedPlayer.isDead) {
             toast.error(`Cannot donate for ${selectedPlayer.name} as they are not dead. If they have recently died, please refresh this page.`, {
                 position: "top-center",
                 autoClose: 10000,
@@ -92,8 +99,7 @@ class Charities extends React.Component<{}, {charities: Charity[], players: Play
             });
             return;
         }
-        let url = `${process.env.REACT_APP_JG_DONATE_URL}${this.state.charityId}?exiturl=${process.env.REACT_APP_API_URL}v1/Callback?data=JUSTGIVING-DONATION-ID~${selectedPlayer.id}`;
-        window.location.replace(url);
+        window.location.replace(this.buildDonationUrl(this.state.charityId, selectedPlayer.id));
     }
 
     toggleModal = () => {

--- a/src/pages/players/Player.css
+++ b/src/pages/players/Player.css
@@ -54,3 +54,22 @@
     align-items: center;
     gap: 10px;
 }
+
+.players-actions {
+    display: flex;
+    justify-content: flex-end;
+    padding: 10px 0;
+}
+
+.buy-revivals-button {
+    font-size: 16px;
+}
+
+.credits-active {
+    color: #d9534f;
+    font-weight: bold;
+}
+
+.credits-empty {
+    color: #888;
+}

--- a/src/pages/players/Players.tsx
+++ b/src/pages/players/Players.tsx
@@ -36,14 +36,28 @@ export default function Players() {
         resetActivity,
     } = useInactivityPoller(fetchPlayers, { intervalMs: 10000, maxTicks: 30 });
 
+    const [buyCreditsMode, setBuyCreditsMode] = useState(false);
+
     const onPlayerDonateClicked = (player: Player) => {
+        setBuyCreditsMode(false);
         setShowPlayerSelector(true);
         setCurrentPlayer(player);
         resetActivity();
     };
 
+    const onBuyRevivalsClicked = () => {
+        setBuyCreditsMode(true);
+        setShowPlayerSelector(true);
+        setCurrentPlayer(null);
+        resetActivity();
+    };
+
     const onModalPlayerSelected = (player: Player, donor: Player) => {
         setShowPlayerSelector(false);
+        if (buyCreditsMode) {
+            window.location.replace(`/charities?playerId=${donor.id}&mode=credits`);
+            return;
+        }
         let url = `/charities?playerId=${player.id}`;
         if (player.id !== donor.id) {
             url += `&donorId=${donor.id}`;
@@ -63,6 +77,9 @@ export default function Players() {
         <div>
             <InactivityModal show={showInactivityModal} toggle={toggleInactivityModal} continueButtonOnClick={onInactivityContinue}/>
             <PlayerSelector players={players} currentPlayer={currentPlayer} show={showPlayerSelector && !showInactivityModal} toggle={toggleModal} playerSelected={onModalPlayerSelected}/>
+            <div className="players-actions">
+                <button className="btn btn-success buy-revivals-button" data-testid="buyRevivalsButton" onClick={onBuyRevivalsClicked}>Buy Revivals</button>
+            </div>
             <table className="players-table table-striped table table-hover table-responsive table-bordered" data-testid="playersTable">
                 <thead className="table-light">
                     <tr>
@@ -71,6 +88,7 @@ export default function Players() {
                         <th>Status</th>
                         <th>Death Count</th>
                         <th>Dontation Total</th>
+                        <th>Revival Credits</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -97,6 +115,9 @@ export default function Players() {
                             </td>
                             <td className="players-table-data" data-testid="playerDeathCount">{player.deaths.length}</td>
                             <td className="players-table-data" data-testid="playerDonationSum">£{getDonationTotal(player.donations)}</td>
+                            <td className="players-table-data player-credits" data-testid="playerCredits">
+                                <span className={(player.credits ?? 0) > 0 ? "credits-active" : "credits-empty"}>{player.credits ?? 0} / 5</span>
+                            </td>
                         </tr>
                     ))
                 }

--- a/src/pages/players/player.ts
+++ b/src/pages/players/player.ts
@@ -3,15 +3,17 @@ import {Donation} from "./donation";
 
 export class Player {
     id : string;
-    name : string; 
+    name : string;
     isDead : boolean;
+    credits: number;
     deaths: Death[];
     donations: Donation[]
-    
-    constructor(id: string, name: string, isDead:boolean, deaths: Death[], donations: Donation[]) {
+
+    constructor(id: string, name: string, isDead:boolean, credits: number, deaths: Death[], donations: Donation[]) {
         this.id = id;
         this.name = name;
         this.isDead = isDead;
+        this.credits = credits;
         this.deaths = deaths;
         this.donations = donations;
     }

--- a/src/tests/Players.test.tsx
+++ b/src/tests/Players.test.tsx
@@ -61,6 +61,51 @@ describe("Players page", function (){
         expect(screen.getByTestId("noPlayers")).toHaveTextContent("No players ☹");
     });
     
+    it('shows credit balance for alive player with credits', async () => {
+        const playerId = "test-credits";
+        const playerMockData = getAlivePlayerWithCredits(playerId, 3);
+        await act(() => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    json: () => Promise.resolve(playerMockData),
+                }),
+            ) as jest.Mock;
+            render(<Players />);
+        });
+        expect(screen.getByTestId("playerCredits")).toHaveTextContent("3 / 5");
+    });
+
+    it('renders Buy Revivals button', async () => {
+        const playerId = "test-credits";
+        const playerMockData = getAlivePlayerWithCredits(playerId, 0);
+        await act(() => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    json: () => Promise.resolve(playerMockData),
+                }),
+            ) as jest.Mock;
+            render(<Players />);
+        });
+        const button = screen.getByTestId("buyRevivalsButton");
+        expect(button).toHaveTextContent("Buy Revivals");
+        expect(button).toHaveClass("btn", "btn-success");
+    });
+
+    it('opens player selector when Buy Revivals clicked', async () => {
+        const playerId = "test-credits";
+        const playerMockData = getAlivePlayerWithCredits(playerId, 0);
+        await act(async () => {
+            global.fetch = jest.fn(() =>
+                Promise.resolve({
+                    json: () => Promise.resolve(playerMockData),
+                }),
+            ) as jest.Mock;
+            render(<Players />);
+        });
+        fireEvent.click(screen.getByTestId("buyRevivalsButton"));
+        expect(screen.getByTestId("playerSelectorHeader")).toHaveTextContent("Who is donating?");
+    });
+
     it('displays player selector when donate button clicked', async () => {
         const playerId = "3a0c7a69-c12f-4f7f-9aaf-3345bb0f2e38";
         const playerMockData = getDeadPlayer(playerId);
@@ -84,15 +129,21 @@ describe("Players page", function (){
     });
 });
 
-function getDeadPlayer(playerId: string) : Player[] {    
+function getDeadPlayer(playerId: string) : Player[] {
     return [
-        new Player(playerId, "TestPlayer", true, getMockDeaths(playerId), getMockDonations(playerId) )
+        new Player(playerId, "TestPlayer", true, 0, getMockDeaths(playerId), getMockDonations(playerId) )
     ];
 }
 
 function getAlivePlayerWithNoDonations(playerId: string): Player[] {
     return [
-        new Player(playerId, "TestPlayer", false, [], [])
+        new Player(playerId, "TestPlayer", false, 0, [], [])
+    ];
+}
+
+function getAlivePlayerWithCredits(playerId: string, credits: number): Player[] {
+    return [
+        new Player(playerId, "TestPlayer", false, credits, [], [])
     ];
 }
 


### PR DESCRIPTION
## Summary
- New Revival Credits column on the Players table showing `N / 5` — red bold when > 0, muted at 0/5.
- New Buy Revivals action above the table. Clicking it opens the existing PlayerSelector in "credits mode", then navigates to `/charities?playerId=X&mode=credits`.
- Charities builds the donation URL with a `credits~` prefix on the callback data when `mode=credits`, and skips its "player not dead" guard in that mode (pre-purchasing happens while alive).

Depends on backend PR https://github.com/DP94/DonateCraft/pull/71 for the `credits` field on Player and the callback branch.

## Test plan
- [x] `jest src/tests/Players.test.tsx` — 7 tests pass (3 new: credit balance rendering, Buy Revivals button, button opens selector)
- [x] `tsc --noEmit` — clean
- [ ] Manual: buy revivals flow end-to-end against local backend
- [ ] Manual: verify existing donate-for-dead-player flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)